### PR TITLE
Add Java7 Update0 dep, modify Firefox 3.6 install

### DIFF
--- a/hashes.txt
+++ b/hashes.txt
@@ -23,3 +23,5 @@ FirefoxSetup3.6.20.exe = 1c66e23d9c65e2c8805da9ae033f254f084b16c7
 PIL-1.1.7.win32-py2.7.exe = 2293618ac972fdda2e43636cbb4e93646b10e343
 
 AdbeRdr90_en_US.exe = 8faabd08289b9a88023f71136f13fc4bd3290ef0
+
+jdk-7-windows-i586.exe = 2546a78b6138466b3e23e25b5ca59f1c89c22d03

--- a/repo.ini
+++ b/repo.ini
@@ -106,4 +106,5 @@ cmd3 = c:\python27\python -c "import time; time.sleep(30)"
 cmd4 = click.exe "Java Setup - Destination Folder" "&Next >"
 cmd5 = c:\python27\python -c "import time; time.sleep(30)"
 cmd6 = click.exe "Java(TM) SE Development Kit 7 - Complete" "&Finish"
-cmd7 = tskill iexplore
+cmd7 = c:\python27\python -c "import time; time.sleep(10)"
+cmd8 = tskill iexplore

--- a/repo.ini
+++ b/repo.ini
@@ -4,11 +4,10 @@ flags = background
 description = Mozilla Firefox 3.6
 cmd0 = c:\python27\python -c "import time; time.sleep(10)"
 cmd1 = click.exe "Mozilla Firefox Setup" "&Next >"
-cmd2 = click.exe "Mozilla Firefox Setup" "&Next >"
-cmd3 = click.exe "Mozilla Firefox Setup" "&Install"
-cmd4 = click.exe "Mozilla Firefox Setup " "&Finish"
-cmd5 = c:\python27\python -c "import time; time.sleep(5)"
-cmd6 = tskill firefox
+cmd2 = click.exe "Mozilla Firefox Setup" "&Install"
+cmd3 = click.exe "Mozilla Firefox Setup " "&Finish"
+cmd4 = c:\python27\python -c "import time; time.sleep(5)"
+cmd5 = tskill firefox
 
 [python27]
 filename = python-2.7.6.msi

--- a/repo.ini
+++ b/repo.ini
@@ -94,3 +94,16 @@ cmd7 = c:\python27\python -c "import time; time.sleep(10)"
 cmd6 = click.exe "Adobe Reader - License Agreement" "Accept"
 cmd7 = c:\python27\python -c "import time; time.sleep(10)"
 cmd8 = tskill acrord32
+
+[java7]
+filename = jdk-7-windows-i586.exe
+flags = background
+description = Java 7.0
+cmd0 = c:\python27\python -c "import time; time.sleep(30)"
+cmd1 = click.exe "Java(TM) SE Development Kit 7 - Setup" "&Next >"
+cmd2 = click.exe "Java(TM) SE Development Kit 7 - Custom Setup" "&Next >"
+cmd3 = c:\python27\python -c "import time; time.sleep(30)"
+cmd4 = click.exe "Java Setup - Destination Folder" "&Next >"
+cmd5 = c:\python27\python -c "import time; time.sleep(30)"
+cmd6 = click.exe "Java(TM) SE Development Kit 7 - Complete" "&Finish"
+cmd7 = tskill iexplore

--- a/urls.txt
+++ b/urls.txt
@@ -20,3 +20,5 @@ FirefoxSetup3.6.20.exe = http://www.oldapps.com/firefox.php?app=74431DF7E360C499
 PIL-1.1.7.win32-py2.7.exe = http://effbot.org/downloads/PIL-1.1.7.win32-py2.7.exe
 
 AdbeRdr90_en_US.exe = http://download.oldapps.com/Adobe_Reader/AdbeRdr90_en_US.exe
+
+jdk-7-windows-i586.exe = http://download.oldapps.com/Java/jdk-7-windows-i586.exe


### PR DESCRIPTION
Add a dependency for Java7 - tested against various live EKs and have had success exploiting

Modified the Firefox 3.6 install process to remove one of the "&Next >" clicks that were causing my installs to hang